### PR TITLE
.today fixed

### DIFF
--- a/src/less/_bootstrap-datetimepicker.less
+++ b/src/less/_bootstrap-datetimepicker.less
@@ -268,7 +268,8 @@
                 &:before {
                     content: '';
                     display: inline-block;
-                    border: 0 0 7px 7px solid transparent;
+                    border: solid transparent;
+                    border-width: 0 0 7px 7px;
                     border-bottom-color: @bs-datetimepicker-active-bg;
                     border-top-color: @bs-datetimepicker-secondary-border-color-rgba;
                     position: absolute;


### PR DESCRIPTION
``.today`` marker wasn't visible because of invalid css-syntax in border property.
[Screenshot](https://yadi.sk/i/GqkQx725hBsq9)